### PR TITLE
zayi ürün girme hatası fix(FE'si de var)

### DIFF
--- a/src/modules/order/order.dto.ts
+++ b/src/modules/order/order.dto.ts
@@ -135,6 +135,10 @@ export class CreateOrderDto {
 
   @IsOptional()
   @IsBoolean()
+  isLossProduct?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
   isReturned?: boolean;
 
   @IsOptional()

--- a/src/modules/order/order.schema.ts
+++ b/src/modules/order/order.schema.ts
@@ -161,6 +161,9 @@ export class Order extends Document {
   isOnlineSale: boolean;
 
   @Prop({ required: false, type: Boolean })
+  isLossProduct: boolean;
+
+  @Prop({ required: false, type: Boolean })
   isReturned: boolean;
 
   @Prop({ required: false, type: Number, ref: Location.name })

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1229,7 +1229,7 @@ export class OrderService {
         HttpStatus.BAD_REQUEST,
       );
     }
-    if (!createOrderDto.isOnlineSale && !createOrderDto.table) {
+    if (!createOrderDto.isOnlineSale && !createOrderDto.isLossProduct && !createOrderDto.table) {
       throw new HttpException(
         'Non-online orders require a table',
         HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
son geliştirmede sipariş oluşturmak için /orders'a oluşturma isteği atmak için masayı zorunlu kılmıştık ama  zayi ürün girerken de createOrder endpointine istek attığımız için, masası olmadığından dolayı hata veriyordu, islossproduct flagi eklenerek sorun çözüldü