### PR TITLE
Shifts sayfasında duplike satır oluşmasının engellenmesi

### DIFF
--- a/src/modules/shift/shift.schema.ts
+++ b/src/modules/shift/shift.schema.ts
@@ -41,4 +41,6 @@ export class Shift extends Document {
 
 export const ShiftSchema = SchemaFactory.createForClass(Shift);
 
+ShiftSchema.index({ day: 1, location: 1 }, { unique: true });
+
 purifySchema(ShiftSchema);

--- a/src/modules/shift/shift.service.ts
+++ b/src/modules/shift/shift.service.ts
@@ -98,6 +98,7 @@ export class ShiftService {
         { shifts: mergedShifts },
         { new: true },
       );
+      this.websocketGateway.emitShiftChanged();
       try {
         await this.activityService.addActivity(user, ActivityType.CREATE_SHIFT, {
           day: updatedShift.day,

--- a/src/modules/shift/shift.service.ts
+++ b/src/modules/shift/shift.service.ts
@@ -76,6 +76,31 @@ export class ShiftService {
   }
 
   async createShift(user: User, createShiftDto: CreateShiftDto) {
+    const existing = await this.shiftModel
+      .findOne({ day: createShiftDto.day, location: createShiftDto.location })
+      .exec();
+
+    if (existing) {
+      const mergedShifts = existing.shifts.map((existingShift) => {
+        const incoming = createShiftDto.shifts?.find(
+          (s) => s.shift === existingShift.shift,
+        );
+        if (!incoming) return existingShift;
+        return {
+          ...existingShift,
+          user: Array.from(
+            new Set([...(existingShift.user ?? []), ...(incoming.user ?? [])]),
+          ),
+        };
+      });
+      const updatedShift = await this.shiftModel.findByIdAndUpdate(
+        existing._id,
+        { shifts: mergedShifts },
+        { new: true },
+      );
+      return updatedShift;
+    }
+
     const createdShift = new this.shiftModel(createShiftDto);
     await createdShift.save();
     this.websocketGateway.emitShiftChanged();

--- a/src/modules/shift/shift.service.ts
+++ b/src/modules/shift/shift.service.ts
@@ -98,6 +98,15 @@ export class ShiftService {
         { shifts: mergedShifts },
         { new: true },
       );
+      try {
+        await this.activityService.addActivity(user, ActivityType.CREATE_SHIFT, {
+          day: updatedShift.day,
+          location: updatedShift.location,
+          shifts: updatedShift.shifts,
+        });
+      } catch (e) {
+        console.error('Failed to log create shift activity', e);
+      }
       return updatedShift;
     }
 


### PR DESCRIPTION
- createShift metodunun başına upsert mantığı eklendi, gelen istek için aynı {day, location} kaydı zaten varsa yeni doküman açmak yerine mevcut kaydın shifts array'i merge edilecek.

- ikinci bir güvenlik katmanı olarak shift.schema.ts'e {day, location} için unique compound index eklendi.