### PR TITLE
Shopify sipariş iptalinde gelen duplike webhook handle edildi

### DIFF
--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -2093,7 +2093,7 @@ export class OrderService {
           this.logger.warn(
             `Order ${shopifyOrderLineItemId} already cancelled, skipping duplicate webhook`,
           );
-          return null;
+          return order;
         }
 
         const collection = await this.collectionModel.findOne(

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -2088,6 +2088,14 @@ export class OrderService {
           throw new HttpException('Order not found', HttpStatus.NOT_FOUND);
         }
 
+        // Duplicate webhook guard: if already cancelled, skip silently
+        if (order.status === OrderStatus.CANCELLED) {
+          this.logger.warn(
+            `Order ${shopifyOrderLineItemId} already cancelled, skipping duplicate webhook`,
+          );
+          return null;
+        }
+
         const collection = await this.collectionModel.findOne(
           {
             shopifyId: order.shopifyOrderId,
@@ -2099,13 +2107,6 @@ export class OrderService {
 
         if (!collection) {
           throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
-        }
-
-        if (order.status === OrderStatus.CANCELLED) {
-          throw new HttpException(
-            'Order is already cancelled',
-            HttpStatus.BAD_REQUEST,
-          );
         }
         if (quantity > order.quantity) {
           throw new HttpException(


### PR DESCRIPTION
Shopify "sipariş iptal" edildiğinde kısa aralıklarla şu sırayla iki event fırlatıyor:

1. orders/refunds/create — iptal işlemi dahili olarak önce bir refund oluşturuyor
2. orders/cancelled — ardından sipariş cancelled statüsüne geçiyor.

Para iadesinde ise sipariş kapatılmıyor, sadece refund oluşturuluyor → sadece orders/refunds/create tetikleniyor.

Biz iki senaryoda da /order-cancel-webhook'a yönlendiriyoruz. Bu webhookun devamındaki is mantığında da sipariş iptal süreci olduğu için ilk iptalden sonra tekrar iptal işlemi denediği için error logları alıyoruz(iptal işlemi sağlıklı gerçekleşiyor)

Bu yeni geliştirme ile diğer webhook geldiğinde error basılması yerine 1 satır uyarı logu ile ikinci webhooku karşılıyoruz.