### PR TITLE
Ortacılığın gece 00:10'da otomatik kapanması

### DIFF
--- a/src/modules/activity/activity.dto.ts
+++ b/src/modules/activity/activity.dto.ts
@@ -95,6 +95,7 @@ export enum ActivityType {
   START_MIDDLEMAN = 'START_MIDDLEMAN',
   FINISH_MIDDLEMAN = 'FINISH_MIDDLEMAN',
   FINISH_MIDDLEMAN_BY_MANAGER = 'FINISH_MIDDLEMAN_BY_MANAGER',
+  FINISH_MIDDLEMAN_AUTO = 'FINISH_MIDDLEMAN_AUTO',
   CREATE_SHIFT = 'CREATE_SHIFT',
   UPDATE_SHIFT = 'UPDATE_SHIFT',
   DELETE_SHIFT = 'DELETE_SHIFT',
@@ -201,6 +202,7 @@ export type ActivityTypePayload = {
   [ActivityType.START_MIDDLEMAN]: Middleman;
   [ActivityType.FINISH_MIDDLEMAN]: Middleman;
   [ActivityType.FINISH_MIDDLEMAN_BY_MANAGER]: Middleman;
+  [ActivityType.FINISH_MIDDLEMAN_AUTO]: Middleman;
   [ActivityType.CREATE_SHIFT]: { day: string; location: number; shifts: ShiftValues[] };
   [ActivityType.UPDATE_SHIFT]: {
     day: string;

--- a/src/modules/middleman/middleman.cron.service.ts
+++ b/src/modules/middleman/middleman.cron.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { MiddlemanService } from './middleman.service';
+
+@Injectable()
+export class MiddlemanCronService {
+  private readonly logger = new Logger(MiddlemanCronService.name);
+
+  constructor(private readonly middlemanService: MiddlemanService) {}
+
+  @Cron('0 10 0 * * *', { timeZone: 'Europe/Istanbul' })
+  async handleAutoCloseStaleMiddlemen() {
+    this.logger.log('🔄 [Cron] Closing stale middleman records…');
+
+    const closedCount = await this.middlemanService.autoCloseStale();
+
+    if (closedCount > 0) {
+      this.logger.log(`✅ Auto-closed ${closedCount} middleman record(s)`);
+    } else {
+      this.logger.log('ℹ️  No stale middleman records found');
+    }
+  }
+}

--- a/src/modules/middleman/middleman.module.ts
+++ b/src/modules/middleman/middleman.module.ts
@@ -6,6 +6,7 @@ import { LocationModule } from '../location/location.module';
 import { UserModule } from '../user/user.module';
 import { WebSocketModule } from '../websocket/websocket.module';
 import { MiddlemanController } from './middleman.controller';
+import { MiddlemanCronService } from './middleman.cron.service';
 import { Middleman, MiddlemanSchema } from './middleman.schema';
 import { MiddlemanService } from './middleman.service';
 
@@ -20,7 +21,7 @@ import { MiddlemanService } from './middleman.service';
     ActivityModule,
   ],
   controllers: [MiddlemanController],
-  providers: [MiddlemanService],
+  providers: [MiddlemanService, MiddlemanCronService],
   exports: [MiddlemanService],
 })
 export class MiddlemanModule {}

--- a/src/modules/middleman/middleman.service.ts
+++ b/src/modules/middleman/middleman.service.ts
@@ -200,8 +200,13 @@ export class MiddlemanService {
   }
 
   async autoCloseStale(): Promise<number> {
-    const turkeyNow = new Date(new Date().getTime() + 3 * 60 * 60 * 1000);
-    const yesterday = format(subDays(turkeyNow, 1), 'yyyy-MM-dd');
+    const yesterdayDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const yesterday = new Intl.DateTimeFormat('sv-SE', {
+      timeZone: 'Europe/Istanbul',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(yesterdayDate);
 
     const stale = await this.middlemanModel.find({
       finishHour: { $exists: false },

--- a/src/modules/middleman/middleman.service.ts
+++ b/src/modules/middleman/middleman.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { format, subDays } from 'date-fns';
 import { FilterQuery, Model } from 'mongoose';
 import { ActivityType } from '../activity/activity.dto';
 import { ActivityService } from '../activity/activity.service';
@@ -196,5 +197,37 @@ export class MiddlemanService {
     assertFound(deleted, 'Middleman record not found');
     this.websocketGateway.emitMiddlemanChanged();
     return deleted;
+  }
+
+  async autoCloseStale(): Promise<number> {
+    const turkeyNow = new Date(new Date().getTime() + 3 * 60 * 60 * 1000);
+    const yesterday = format(subDays(turkeyNow, 1), 'yyyy-MM-dd');
+
+    const stale = await this.middlemanModel.find({
+      finishHour: { $exists: false },
+      date: yesterday,
+    });
+
+    if (stale.length === 0) return 0;
+
+    await this.middlemanModel.updateMany(
+      { _id: { $in: stale.map((s) => s._id) } },
+      { $set: { finishHour: '23:59' } },
+    );
+
+    for (const record of stale) {
+      record.finishHour = '23:59';
+      await tryAddActivity(
+        this.activityService,
+        this.userService,
+        record.user,
+        ActivityType.FINISH_MIDDLEMAN_AUTO,
+        toPlainObject(record),
+        'auto-close stale middleman',
+      );
+    }
+
+    this.websocketGateway.emitMiddlemanChanged();
+    return stale.length;
   }
 }


### PR DESCRIPTION
- Kullanıcı bitirmeyi unutursa kayıt açık kalıyor ve ertesi gün yeni ortacılık başlatılamıyordu.
- Her gece Türkiye saatiyle 00:10'da çalışan cron, bir önceki güne ait açık kayıtları finishHour="23:59" ile kapatıyor.
- Websocket yayını sayesinde açık overlay'ler kendiliğinden kapanıyor.
- Her otomatik kapatma için FINISH_MIDDLEMAN_AUTO aktivitesi üretiliyor; raporlarda manager kapatması ile sistem kapatması ayrışıyor.