### PR TITLE
feat(notification): kullanıcı bildirimi tek tek susturabilsin

### DIFF
--- a/src/modules/notification/notification.controller.ts
+++ b/src/modules/notification/notification.controller.ts
@@ -90,6 +90,15 @@ export class NotificationController {
       event,
     });
   }
+
+  @Patch('/:id/mute')
+  toggleMute(
+    @ReqUser() user: User,
+    @Param('id') id: number,
+    @Body() body: { userId?: string; mute: boolean },
+  ) {
+    return this.notificationService.toggleMute(user, id, body.userId, body.mute);
+  }
   @Patch('/:id')
   updateGame(
     @ReqUser() user: User,

--- a/src/modules/notification/notification.dto.ts
+++ b/src/modules/notification/notification.dto.ts
@@ -9,6 +9,7 @@ export class CreateNotificationDto {
   selectedRoles?: number[];
   selectedLocations?: number[];
   seenBy?: string[];
+  mutedBy?: string[];
   event?: string;
   isAssigned?: boolean;
   isActive?: boolean;

--- a/src/modules/notification/notification.schema.ts
+++ b/src/modules/notification/notification.schema.ts
@@ -42,6 +42,9 @@ export class Notification extends Document {
   @Prop({ required: false, type: [{ type: String, ref: User.name }] })
   seenBy: string[];
 
+  @Prop({ required: false, type: [{ type: String, ref: User.name }], default: [] })
+  mutedBy: string[];
+
   @Prop({ required: false, type: String })
   event: string;
 

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, UpdateQuery } from 'mongoose';
 import { LocationService } from '../location/location.service';
+import { RoleEnum } from '../user/user.dto';
 import { User } from '../user/user.schema';
 import { UserService } from '../user/user.service';
 import { VisitService } from '../visit/visit.service';
@@ -185,6 +186,7 @@ export class NotificationService {
       const notifications = await this.notificationModel
         .find({
           seenBy: { $ne: user._id },
+          mutedBy: { $ne: user._id },
           $or: [{ selectedUsers: user._id }, { selectedRoles: user.role._id }],
         })
         .sort({ createdAt: -1 })
@@ -277,6 +279,7 @@ export class NotificationService {
         return null;
       }
       if (!createNotificationDto?.isAssigned && assignedTemplate) {
+        finalCreateDto.mutedBy = assignedTemplate.mutedBy ?? [];
         const selectedLocations = this.sanitizeSelectedLocations(
           assignedTemplate.selectedLocations,
         );
@@ -357,6 +360,49 @@ export class NotificationService {
     });
     this.websocketGateway.emitNotificationChanged([notification]);
     return notification;
+  }
+
+  async toggleMute(
+    requester: User,
+    id: number,
+    targetUserId: string | undefined,
+    mute: boolean,
+  ) {
+    const effectiveUserId = targetUserId ?? requester._id;
+
+    if (targetUserId && targetUserId !== requester._id) {
+      if (requester.role?._id !== RoleEnum.MANAGER) {
+        throw new HttpException(
+          'Only managers can mute notifications for other users',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+    }
+
+    const update = mute
+      ? { $addToSet: { mutedBy: effectiveUserId } }
+      : { $pull: { mutedBy: effectiveUserId } };
+
+    try {
+      const notification = await this.notificationModel.findByIdAndUpdate(
+        id,
+        update,
+        { new: true },
+      );
+      if (!notification) {
+        throw new HttpException('Notification not found', HttpStatus.NOT_FOUND);
+      }
+      this.websocketGateway.emitNotificationChanged([notification]);
+      return notification;
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Failed to toggle mute',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 
   async markAsRead(user: User, notificationIds: number[]) {


### PR DESCRIPTION
- Notification şemasına mutedBy eklendi, eski kayıtlar bozulmasın diye default boş array
- PATCH /notification/:id/mute eklendi, toggleMute servisinde kullanıcı kendini susturabiliyor; manager da başkası için yapabiliyor
- Bell ikonunun /new sorgusuna mutedBy filtresi eklendi, susturulan bildirimler artık görünmüyor