### PR TITLE
fix : QR giriş/çıkış saatinin UTC sunucuda 3 saat geri kaydedilmesi düzeltildi

### DIFF
--- a/src/modules/reservation/reservation.service.ts
+++ b/src/modules/reservation/reservation.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { addHours, addMinutes, format } from 'date-fns';
+import * as moment from 'moment-timezone';
 import { Model, UpdateQuery } from 'mongoose';
 import { ActivityType } from '../activity/activity.dto';
 import { ActivityService } from '../activity/activity.service';
@@ -25,7 +25,7 @@ export class ReservationService {
     const lastReservation = await this.reservationModel
       .findOne({})
       .sort({ order: 'desc' });
-    const date = format(new Date(), 'yyyy-MM-dd');
+    const date = moment.tz('Europe/Istanbul').format('YYYY-MM-DD');
     const reservation = await this.reservationModel.create({
       ...reservationDto,
       date,
@@ -75,8 +75,7 @@ export class ReservationService {
   }
 
   async callUpdate(user: User, id: number, updates: UpdateQuery<Reservation>) {
-    const gmtPlus3Now = addHours(new Date(), 3);
-    const callHour = format(gmtPlus3Now, 'HH:mm');
+    const callHour = moment.tz('Europe/Istanbul').format('HH:mm');
     const oldReservation = await this.reservationModel.findById(id);
     const reservationUpdates = updates as ReservationUpdatePayload;
     const duration = reservationUpdates.comingDurationInMinutes ?? 30;
@@ -91,8 +90,8 @@ export class ReservationService {
           reservedTable: updateWithoutDuration.reservedTable,
         }),
         ...(updateWithoutDuration.status === 'Coming' && {
-          approvedHour: format(gmtPlus3Now, 'HH:mm'),
-          comingExpiresAt: addMinutes(gmtPlus3Now, duration),
+          approvedHour: callHour,
+          comingExpiresAt: moment().add(duration, 'minutes').toDate(),
         }),
         ...(updateWithoutDuration.status !== 'Coming' && {
           comingExpiresAt: null,
@@ -135,10 +134,9 @@ export class ReservationService {
   }
 
   async cancelExpiredComingReservations() {
-    const gmtPlus3Now = addHours(new Date(), 3);
     const expiredReservations = await this.reservationModel.find({
       status: 'Coming',
-      comingExpiresAt: { $lt: gmtPlus3Now },
+      comingExpiresAt: { $lt: new Date() },
     });
 
     for (const reservation of expiredReservations) {

--- a/src/modules/table/table.service.ts
+++ b/src/modules/table/table.service.ts
@@ -7,7 +7,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { addDays, format, subDays } from 'date-fns';
+import { addDays, format } from 'date-fns';
+import * as moment from 'moment-timezone';
 import { Model, PipelineStage, UpdateQuery } from 'mongoose';
 import { DailyPlayerCount } from 'src/types';
 import { pick, pickWith } from 'src/utils/tsUtils';
@@ -767,24 +768,12 @@ export class TableService {
     return table;
   }
   async notifyUnclosedTables() {
-    function formatDate(date: Date): string {
-      const yyyy = date.getFullYear();
-      const mm = String(date.getMonth() + 1).padStart(2, '0');
-      const dd = String(date.getDate()).padStart(2, '0');
-      return `${yyyy}-${mm}-${dd}`;
-    }
-
-    function getTurkishDateOffset(): Date {
-      const nowUTC = new Date();
-      const offsetInMs = 3 * 60 * 60 * 1000; // GMT+3 => 3 saat ileri
-      return new Date(nowUTC.getTime() + offsetInMs);
-    }
-
-    const todayTR = getTurkishDateOffset();
-    const yesterdayTR = subDays(todayTR, 1);
-
-    const todayStr = formatDate(todayTR);
-    const yesterdayStr = formatDate(yesterdayTR);
+    const istanbulNow = moment.tz('Europe/Istanbul');
+    const todayStr = istanbulNow.format('YYYY-MM-DD');
+    const yesterdayStr = istanbulNow
+      .clone()
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
 
     const unclosedTables = await this.tableModel.find({
       date: { $in: [todayStr, yesterdayStr] },

--- a/src/modules/visit/visit.service.ts
+++ b/src/modules/visit/visit.service.ts
@@ -7,7 +7,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { addHours, format, subDays } from 'date-fns';
+import { format, subDays } from 'date-fns';
+import * as moment from 'moment-timezone';
 import { Model, UpdateQuery } from 'mongoose';
 import { ActivityType } from '../activity/activity.dto';
 import { ActivityService } from '../activity/activity.service';
@@ -606,10 +607,13 @@ export class VisitService {
   async checkInOutWithQr(user: User, code: string) {
     const location = await this.qrCodeService.consume(code);
 
-    const gmtPlus3Now = addHours(new Date(), 3);
-    const date = format(gmtPlus3Now, 'yyyy-MM-dd');
-    const hour = format(gmtPlus3Now, 'HH:mm');
-    const previousDay = format(subDays(gmtPlus3Now, 1), 'yyyy-MM-dd');
+    const istanbulNow = moment.tz('Europe/Istanbul');
+    const date = istanbulNow.format('YYYY-MM-DD');
+    const hour = istanbulNow.format('HH:mm');
+    const previousDay = istanbulNow
+      .clone()
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
 
     const lastVisit = await this.visitModel
       .findOne({ user: user._id, location, date: { $in: [date, previousDay] } })

--- a/src/modules/visit/visit.service.ts
+++ b/src/modules/visit/visit.service.ts
@@ -7,7 +7,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { format, subDays } from 'date-fns';
+import { addHours, format, subDays } from 'date-fns';
 import { Model, UpdateQuery } from 'mongoose';
 import { ActivityType } from '../activity/activity.dto';
 import { ActivityService } from '../activity/activity.service';
@@ -605,9 +605,11 @@ export class VisitService {
 
   async checkInOutWithQr(user: User, code: string) {
     const location = await this.qrCodeService.consume(code);
-    const date = format(new Date(), 'yyyy-MM-dd');
-    const hour = format(new Date(), 'HH:mm');
-    const previousDay = format(subDays(new Date(), 1), 'yyyy-MM-dd');
+
+    const gmtPlus3Now = addHours(new Date(), 3);
+    const date = format(gmtPlus3Now, 'yyyy-MM-dd');
+    const hour = format(gmtPlus3Now, 'HH:mm');
+    const previousDay = format(subDays(gmtPlus3Now, 1), 'yyyy-MM-dd');
 
     const lastVisit = await this.visitModel
       .findOne({ user: user._id, location, date: { $in: [date, previousDay] } })


### PR DESCRIPTION
QR check-in/out saatini düz format(new Date()) ile hesaplıyorduk; sunucu UTC çalıştığı için saat Türkiye'den 3 saat geri kaydoluyordu. Saati reservation.service'teki gibi addHours(new Date(), 3) ile Türkiye saatine (UTC+3) çevirdik.