### PR TITLE
(henüz tamamlanmadı)fix: İade işleminde paidQuantity hatalı setlenmesinin düzeltilmesi

### DIFF
--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1550,6 +1550,7 @@ export class OrderService {
         const newOrder = await this.orderModel.create({
           ...orderWithoutId,
           quantity: remainingQuantity,
+          paidQuantity: Math.max(0, (order.paidQuantity ?? 0) - returnQuantity),
         });
 
         if (collection) {

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1550,7 +1550,6 @@ export class OrderService {
         const newOrder = await this.orderModel.create({
           ...orderWithoutId,
           quantity: remainingQuantity,
-          paidQuantity: remainingQuantity,
         });
 
         if (collection) {
@@ -1634,6 +1633,7 @@ export class OrderService {
           id,
           {
             status: OrderStatus.RETURNED,
+            paidQuantity: returnQuantity,
             cancelledAt,
             cancelledBy: user._id,
           },


### PR DESCRIPTION
- İade oluşturunca gerçekleşen sipariş bölünmesi sırasında "bölünen" siparişte `paidQuantity` set ediliyordu
- `paidQuantity` artık yalnızca iade (`RETURNED`) statusüne geçişte, "bölünmüş olan" parçaya `returnQuantity` değeriyle doğru şekilde atanıyor