### PR TITLE
fix: İade işlemlerindeki hatalı hesaplama ve senkronizasyon sorunlarının düzeltilmesi

### DIFF
--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1550,6 +1550,7 @@ export class OrderService {
         const newOrder = await this.orderModel.create({
           ...orderWithoutId,
           quantity: remainingQuantity,
+          paidQuantity: Math.max(0, (order.paidQuantity ?? 0) - returnQuantity),
         });
 
         if (collection) {

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1550,7 +1550,6 @@ export class OrderService {
         const newOrder = await this.orderModel.create({
           ...orderWithoutId,
           quantity: remainingQuantity,
-          paidQuantity: remainingQuantity,
         });
 
         if (collection) {
@@ -1634,6 +1633,7 @@ export class OrderService {
           id,
           {
             status: OrderStatus.RETURNED,
+            paidQuantity: returnQuantity,
             cancelledAt,
             cancelledBy: user._id,
           },

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -1566,16 +1566,20 @@ export class OrderService {
             });
             this.websocketGateway.emitCollectionChanged(newCollection);
 
-            await this.collectionModel.findByIdAndUpdate(
-              collection._id,
-              {
-                status: OrderCollectionStatus.RETURNED,
-                orders: [{ order: id, paidQuantity: returnQuantity }],
-                amount: returnedAmount,
-                cancelledAt,
-                cancelledBy: user._id,
-              },
-              { new: true },
+            const updatedReturnedCollection =
+              await this.collectionModel.findByIdAndUpdate(
+                collection._id,
+                {
+                  status: OrderCollectionStatus.RETURNED,
+                  orders: [{ order: id, paidQuantity: returnQuantity }],
+                  amount: returnedAmount,
+                  cancelledAt,
+                  cancelledBy: user._id,
+                },
+                { new: true },
+              );
+            this.websocketGateway.emitCollectionChanged(
+              updatedReturnedCollection,
             );
           } else {
             // Multi-order collection: replace this order with the new remainder order,
@@ -1588,18 +1592,20 @@ export class OrderService {
               },
               { new: true },
             );
-            await this.collectionModel.findByIdAndUpdate(
-              collection._id,
-              {
-                $push: {
-                  orders: {
-                    order: newOrder._id,
-                    paidQuantity: remainingQuantity,
+            const updatedMultiCollection =
+              await this.collectionModel.findByIdAndUpdate(
+                collection._id,
+                {
+                  $push: {
+                    orders: {
+                      order: newOrder._id,
+                      paidQuantity: remainingQuantity,
+                    },
                   },
                 },
-              },
-              { new: true },
-            );
+                { new: true },
+              );
+            this.websocketGateway.emitCollectionChanged(updatedMultiCollection);
 
             const returnedCollection = await this.collectionModel.create({
               ...collection.toObject(),
@@ -1644,26 +1650,30 @@ export class OrderService {
         if (collection) {
           if (isLastOrderInCollection) {
             // Only order in collection: mark entire collection as returned
-            await this.collectionModel.findByIdAndUpdate(
-              collection._id,
-              {
-                status: OrderCollectionStatus.RETURNED,
-                cancelledAt,
-                cancelledBy: user._id,
-              },
-              { new: true },
-            );
+            const updatedCollection =
+              await this.collectionModel.findByIdAndUpdate(
+                collection._id,
+                {
+                  status: OrderCollectionStatus.RETURNED,
+                  cancelledAt,
+                  cancelledBy: user._id,
+                },
+                { new: true },
+              );
+            this.websocketGateway.emitCollectionChanged(updatedCollection);
           } else {
             // Multi-order collection: remove this order, reduce amount,
             // create a separate returned collection for audit
-            await this.collectionModel.findByIdAndUpdate(
-              collection._id,
-              {
-                $pull: { orders: { order: id } },
-                $inc: { amount: -returnedAmount },
-              },
-              { new: true },
-            );
+            const updatedCollection =
+              await this.collectionModel.findByIdAndUpdate(
+                collection._id,
+                {
+                  $pull: { orders: { order: id } },
+                  $inc: { amount: -returnedAmount },
+                },
+                { new: true },
+              );
+            this.websocketGateway.emitCollectionChanged(updatedCollection);
 
             const returnedCollection = await this.collectionModel.create({
               ...collection.toObject(),
@@ -3809,7 +3819,12 @@ export class OrderService {
             .find(
               {
                 table: tableId,
-                status: { $ne: OrderCollectionStatus.CANCELLED },
+                status: {
+                  $nin: [
+                    OrderCollectionStatus.CANCELLED,
+                    OrderCollectionStatus.RETURNED,
+                  ],
+                },
               },
               { amount: 1 },
               { session },


### PR DESCRIPTION
- Kısmi iade sırasında bölünen siparişte (`newOrder`) `paidQuantity`, spread operatörü aracılığıyla orijinal siparişten hatalı miras alınıyordu; orijinal `paidQuantity`'den iade miktarı çıkarılarak hesaplanacak şekilde düzeltildi
- Tam iade sırasında tam iade edilen siparişe `paidQuantity` atanmıyordu; `returnQuantity` olarak setlendi
- Kısmi ve tam iade akışlarında collection güncellendikten sonra `emitCollectionChanged` çağrısı eksikti; ilgili tüm noktalara eklendi
- Yeni tahsilat oluşturulurken `RETURNED` durumdaki tahsilatlar "zaten tahsil edilmiş" olarak sayılıyordu; bu durum iade sonrası aynı masaya yeni sipariş girildiğinde ödeme yapılamamasına sebep oluyordu; `RETURNED` tahsilatlar doğrulama sorgusundan hariç tutuldu